### PR TITLE
Fix incorrect comments in Atom.

### DIFF
--- a/settings/atom.cson
+++ b/settings/atom.cson
@@ -1,4 +1,4 @@
-'.source.eschema':
+'.source.edgeql':
   'editor':
     'autoIndentOnPaste': false
     'softTabs': true


### PR DESCRIPTION
Comments shortcut in Atom now produces correct `# ...` comments.

Fixes #12.