### PR TITLE
Add support for EdgeQL embedded in JS/TS

### DIFF
--- a/grammars/edgeql.js.json
+++ b/grammars/edgeql.js.json
@@ -1,0 +1,31 @@
+{
+  "fileTypes": ["js", "jsx", "ts", "tsx"],
+  "injectionSelector": "L:source -string -comment",
+  "patterns": [
+    {
+      "name": "commentTaggedTemplate",
+      "contentName": "meta.embedded.block.edgeql",
+      "begin": "(`)(#\\s*edgeql)",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.definition.string.template.begin.js"
+        },
+        "2": {
+          "name": "comment.line.number-sign.edgeql"
+        }
+      },
+      "end": "`",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.template.end.js"
+        }
+      },
+      "patterns": [
+        {
+          "include": "source.edgeql"
+        }
+      ]
+    }
+  ],
+  "scopeName": "inline.edgeql"
+}

--- a/package.json
+++ b/package.json
@@ -47,6 +47,19 @@
         "language": "edgeql",
         "scopeName": "source.edgeql",
         "path": "./grammars/edgeql.tmLanguage"
+      },
+      {
+        "injectTo": [
+          "source.js",
+          "source.ts",
+          "source.tsx",
+          "source.jsx"
+        ],
+        "scopeName": "inline.edgeql",
+        "path": "./grammars/edgeql.js.json",
+        "embeddedLanguages": {
+          "meta.embedded.block.edgeql": "edgeql"
+        }
       }
     ]
   },


### PR DESCRIPTION
This adds support for recognizing EdgeQL queries in template strings in JS using a comment on the opening line. E.g.:

<img width="339" alt="example" src="https://user-images.githubusercontent.com/81224/185805685-04ec492a-c567-4a69-80bd-753d82d44128.png">
