### PR TITLE
Add highlighting support for ReScript

### DIFF
--- a/grammars/edgeql.res.json
+++ b/grammars/edgeql.res.json
@@ -1,0 +1,25 @@
+{
+  "fileTypes": ["res", "resi"],
+  "injectionSelector": "L:source -string -comment",
+  "patterns": [
+    {
+      "contentName": "meta.embedded.block.edgeql",
+      "begin": "(%edgeql\\()\\s*$",
+      "end": "(?<=\\))",
+      "patterns": [
+        {
+          "begin": "^\\s*(`)$",
+          "end": "^\\s*(`)",
+          "patterns": [{ "include": "source.edgeql" }]
+        }
+      ]
+    },
+    {
+      "contentName": "meta.embedded.block.edgeql",
+      "begin": "(%edgeql\\(`)",
+      "end": "(\\`( )?\\))",
+      "patterns": [{ "include": "source.edgeql" }]
+    }
+  ],
+  "scopeName": "inline.edgeql"
+}

--- a/package.json
+++ b/package.json
@@ -60,6 +60,16 @@
         "embeddedLanguages": {
           "meta.embedded.block.edgeql": "edgeql"
         }
+      },
+      {
+        "injectTo": [
+          "source.rescript"
+        ],
+        "scopeName": "inline.edgeql",
+        "path": "./grammars/edgeql.res.json",
+        "embeddedLanguages": {
+          "meta.embedded.block.edgeql": "edgeql"
+        }
       }
     ]
   },


### PR DESCRIPTION
Adds highlighting support for embedding EdgeQL inside of [ReScript](https://rescript-lang.org/).

![image](https://github.com/edgedb/edgedb-editor-plugin/assets/1457626/294585b4-756d-4019-9fc8-0f0d6903b073)

Accompanies `rescript-edgedb` which is just about to be finished/released.