### PR TITLE
Add .cjs and .mjs to the Javascript fileTypes array

### DIFF
--- a/grammars/edgeql.js.json
+++ b/grammars/edgeql.js.json
@@ -1,5 +1,5 @@
 {
-  "fileTypes": ["js", "jsx", "ts", "tsx"],
+  "fileTypes": ["js", "jsx", "ts", "tsx", "cjs", "mjs"],
   "injectionSelector": "L:source -string -comment",
   "patterns": [
     {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,9 @@
           "source.js",
           "source.ts",
           "source.tsx",
-          "source.jsx"
+          "source.jsx",
+          "source.cjs",
+          "source.mjs"
         ],
         "scopeName": "inline.edgeql",
         "path": "./grammars/edgeql.js.json",


### PR DESCRIPTION
This PR adds .cjs and .mjs to the list of recognized JavaScript file extensions. They're not super common, but you'll definitely run into them every now and then.




