### PR TITLE
Support for Highlighting EdgeQL within Tagged Template Literals in JavaScript Files

### DIFF
--- a/grammars/edgeql.js.json
+++ b/grammars/edgeql.js.json
@@ -5,7 +5,7 @@
     {
       "name": "commentTaggedTemplate",
       "contentName": "meta.embedded.block.edgeql",
-      "begin": "(#\\s*edgeql\\s*`|edgeql\\s*`)",
+      "begin": "(`)(#\\s*edgeql)",
       "beginCaptures": {
         "1": {
           "name": "punctuation.definition.string.template.begin.js"
@@ -25,7 +25,56 @@
           "include": "source.edgeql"
         }
       ]
+    },
+    {
+      "name": "tagged-template.edgeql",
+      "contentName": "meta.embedded.block.edgeql",
+      "begin": "\\b(edgeql)(`)",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.name.function.tagged-template.js"
+        },
+        "2": {
+          "name": "punctuation.definition.string.begin.js"
+        }
+      },
+      "end": "\\2",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.js"
+        }
+      },
+      "patterns": [
+        {
+          "include": "source.edgeql"
+        }
+      ]
+    },
+    {
+      "name": "multilinecomment.edgeql",
+      "contentName": "meta.embedded.block.edgeql",
+      "begin": "(/\\**\\s*edgeql\\s*\\**/)\\s*(`|'|\")",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.definition.comment.js"
+        },
+        "2": {
+          "name": "punctuation.definition.string.template.start.js"
+        }
+      },
+      "end": "\\2",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.template.end.js"
+        }
+      },
+      "patterns": [
+        {
+          "include": "source.edgeql"
+        }
+      ]
     }
   ],
+
   "scopeName": "inline.edgeql"
 }

--- a/grammars/edgeql.js.json
+++ b/grammars/edgeql.js.json
@@ -5,7 +5,7 @@
     {
       "name": "commentTaggedTemplate",
       "contentName": "meta.embedded.block.edgeql",
-      "begin": "(`)(#\\s*edgeql)",
+      "begin": "(#\\s*edgeql\\s*`|edgeql\\s*`)",
       "beginCaptures": {
         "1": {
           "name": "punctuation.definition.string.template.begin.js"


### PR DESCRIPTION
### Context
I just discovered that we can get syntax highlighting when EdgeQL code is placed within comment tags (`# edgeql`) within Javascript code. This is a useful feature but I thought it would be nicer to have a tagged template literal, similar to [graphql-tag](https://github.com/apollographql/graphql-tag?tab=readme-ov-file#graphql-tag) for GraphQL

### Proposal
I propose enhancing the existing plugin to also recognize tagged template literals for triggering EdgeQL syntax highlighting within .js and .tsx files. The idea is to adapt the existing regular expression to match both comment-based and tag-based highlighting, like so:

```json
"begin": "(#\\s*edgeql\\s*`|edgeql\\s*`)"
```

### Benefits
- Provides a more flexible/pretty way to include EdgeQL queries within application code, improving readability.
- Lays the groundwork for more advanced linting capabilities in the future, if a real tagged template literal for EdgeQL is developed.

### Questions
- Are there any plans to introduce a tagged template literal included in the Javascript client for EdgeQL to enable advanced linting, beyond just syntax highlighting?
- If not, would this be a welcome contribution from the community?