### PR TITLE
Add a note to README file about JavaScript syntax injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,18 @@ ESDL (EdgeDB Schema Definition Language).  The plugin is designed to work with
 In **Atom** and **Visual Studio Code** install the `edgedb` package.
 
 In **Sublime Text**, install the `EdgeDB` package via "Package Control".
+
+## Additional Features
+
+### Syntax Injection for Embedded Queries
+
+If you're working with embedded EdgeQL queries in a JavaScript file, syntax injection via comments is available. Simply include `# edgeql` within the backticks to enable highlighting. This will make it easier to spot syntax errors and make your embedded queries more readable.
+
+Example:
+
+```javascript
+const query = `
+  # edgeql
+  SELECT ... 
+`;
+```


### PR DESCRIPTION
I just noticed the plugin supports syntax injection in JavaScript, which is great because without it, the developer experience is somewhat lacking. However, I think this feature isn't documented. I've drafted a brief section to address this.