### PR TITLE
Add support for syntax highlighting of embed EdgeQL blocks in Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,17 +18,26 @@ In **Atom** and **Visual Studio Code** install the `edgedb` package.
 
 In **Sublime Text**, install the `EdgeDB` package via "Package Control".
 
-## Additional Features
 
-### Syntax Injection for Embedded Queries
+## Syntax highlighting for embedded code blocks
 
-If you're working with embedded EdgeQL queries in a JavaScript file, syntax injection via comments is available. Simply include `# edgeql` within the backticks to enable highlighting. This will make it easier to spot syntax errors and make your embedded queries more readable.
+This extension also provides syntax highlighting within string literals of other languages such as JavaScript and Go.
+To enable the highlighting, include `# edgeql` in a backtick-quoted string.
+This will make it easier to spot syntax errors and make your embedded queries more readable.
 
-Example:
+```go
+// Go
+query := `#edgeql
+select Example { * };
+`
+```
 
 ```javascript
+// JavaScript
 const query = `
   # edgeql
   SELECT ... 
 `;
 ```
+
+Other languages are not yet implemented, but we are accepting pull requests at [edgedb-editor-plugin](https://github.com/edgedb/edgedb-editor-plugin).

--- a/grammars/edgeql.go.json
+++ b/grammars/edgeql.go.json
@@ -1,0 +1,21 @@
+{
+  "fileTypes": ["go"],
+  "injectionSelector": "L:source -string -comment",
+  "patterns": [
+    {
+      "name": "comment-tagged-template.edgeql",
+      "contentName": "meta.embedded.block.edgeql",
+      "begin": "(`)(#\\s*edgeql[^\n]*)",
+      "end": "(`)",
+      "beginCaptures": {
+        "1": { "name": "punctuation.definition.string.begin.go" },
+        "2": { "name": "comment.line.number-sign.edgeql" }
+      },
+      "endCaptures": {
+        "1": { "name": "punctuation.definition.string.end.go" }
+      },
+      "patterns": [{ "include": "source.edgeql" }]
+    }
+  ],
+  "scopeName": "inline.edgeql"
+}

--- a/package.json
+++ b/package.json
@@ -72,6 +72,16 @@
         "embeddedLanguages": {
           "meta.embedded.block.edgeql": "edgeql"
         }
+      },
+      {
+        "path": "./grammars/edgeql.go.json",
+        "scopeName": "inline.edgeql",
+        "injectTo": [
+          "source.go"
+        ],
+        "embeddedLanguages": {
+          "meta.embedded.block.edgeql": "edgeql"
+        }
       }
     ]
   },


### PR DESCRIPTION
This is a barebone port of the feature already provided for javascript.